### PR TITLE
OutputExtensions における ローカル関数 Shift<T> のときに Value.Count が 0 なら default を返すように修正（エラーにならない様に修正）

### DIFF
--- a/Ddr.Ssq/Printing/OutputExtensions.cs
+++ b/Ddr.Ssq/Printing/OutputExtensions.cs
@@ -240,6 +240,8 @@ namespace Ddr.Ssq.Printing
                 static T Shift<T>(IList<T> Value)
                 {
                     var Count = Value.Count;
+                    if (Value.Count == 0)
+                        return default(T)!;
                     var V = Value[Count - 1];
                     Value.RemoveAt(Count - 1);
                     return V;


### PR DESCRIPTION
OutputExtensions における ローカル関数 Shift<T> のときに Value.Count が 0 なら default を返すように修正（エラーにならない様に修正）